### PR TITLE
Support for Alacritty 0.14

### DIFF
--- a/with_alacritty/core.py
+++ b/with_alacritty/core.py
@@ -213,7 +213,8 @@ def _generate_merged_config(pid: int):
     ]
 
     merged = reduce(merge, configs, {})
-    merged["live_config_reload"] = (
+    merged["general"] = merged.get("general", {})
+    merged["general"]["live_config_reload"] = (
         True  # this whole thing relies upon this setting being enabled.
     )
 


### PR DESCRIPTION
Alacritty 0.14.0 moved `live_config_reload` in a new `general` section. See
<https://alacritty.org/changelog_0_14_0.html#Changed>.