### PR TITLE
Allow Alacritty to deal with DPI

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -24,10 +24,6 @@ let
   #  > and isn't too much work, though it is a bit hacky.
   # TODO: replace this with new IPC mechanism: https://github.com/alacritty/alacritty/commit/4ddb608563d985060d69594d1004550a680ae3bd
   alacritty-direct = pkgs.writeShellScriptBin "alacritty" ''
-    # Don't let alacritty guess the DPI of the screen: it only affects new
-    # terminals. Instead, let our `autoperipherals` script handle everything.
-    # See https://github.com/alacritty/alacritty/issues/5449 for details.
-    export WINIT_X11_SCALE_FACTOR=1.0
     exec ${with-alacritty}/bin/with-alacritty alacritty "$@"
   '';
 in


### PR DESCRIPTION
A while ago, Alacritty gained the ability to react to DPI changes. This issue was tracked in `winit` (a windowing library Alacritty uses): https://github.com/rust-windowing/winit/issues/1228

- https://github.com/rust-windowing/winit/commit/df8805c0d27ca3172f4fa1a6bc1bf9709c4c8d0b fixed the issue, and landed in `winit` v0.30.0
- https://github.com/alacritty/alacritty/commit/48c088a50c977dfaf2a5a7052a5ddd39071e6063#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87e upgraded alacritty to use winit v0.30.0, and landed in Alacritty v0.14.0.