### PR TITLE
Update deps, add missing `format`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715534503,
-        "narHash": "sha256-5ZSVkFadZbFP1THataCaSf0JH2cAH3S29hU9rrxTEqk=",
+        "lastModified": 1751637120,
+        "narHash": "sha256-xVNy/XopSfIG9c46nRmPaKfH1Gn/56vQ8++xWA8itO4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2057814051972fa1453ddfb0d98badbea9b83c06",
+        "rev": "5c724ed1388e53cc231ed98330a60eb2f7be4be3",
         "type": "github"
       },
       "original": {

--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -6,10 +6,13 @@
 , pytestCheckHook
 , pyxdg
 , tomli-w
+, setuptools
 }:
 buildPythonApplication {
   pname = "with-alacritty";
   version = "1.0";
+  pyproject = true;
+  build-system = [ setuptools ];
 
   checkInputs = [ pytestCheckHook ];
   pytestFlagsArray = [ "--ignore=result" ];


### PR DESCRIPTION
With the latest version of nixpkgs, the build started failing:

```
$ nix build .
...
error: with-alacritty-1.0 does not configure a `format`. To build with setuptools as before, set `pyproject = true` and `build-system = [ setuptools ]`.`
```

This fixes that.