### PR TITLE
Remove deprecated `pytestFlagsArray`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751637120,
-        "narHash": "sha256-xVNy/XopSfIG9c46nRmPaKfH1Gn/56vQ8++xWA8itO4=",
+        "lastModified": 1777641297,
+        "narHash": "sha256-WNGcmeOZ8Tr9dq6ztCspYbzWFswr2mPebM9LpsfGxPk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5c724ed1388e53cc231ed98330a60eb2f7be4be3",
+        "rev": "c6d65881c5624c9cae5ea6cedef24699b0c0a4c0",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Let's make with-alacritty available for nix!";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   };
 
   outputs = { self, nixpkgs }: {

--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -15,7 +15,7 @@ buildPythonApplication {
   build-system = [ setuptools ];
 
   checkInputs = [ pytestCheckHook ];
-  pytestFlagsArray = [ "--ignore=result" ];
+  pytestFlags = [ "--ignore=result" ];
 
   propagatedBuildInputs = [
     mergedeep


### PR DESCRIPTION
I had to switch to the `nixpkgs-unstable` channel (which we should have been using anyways, as we don't depend on having any nixos specific packages built) and run `nix flake update` to pull in <https://github.com/nixos/nixpkgs/commit/82da9cf45c21f9b93b48d8ef40ff6005dfc5a53b> to reproduce the issue.

Before:

```console
$ nix build
...
       error: buildPythonPackage: Deprecated flag pytestFlagsArray found at /nix/store/hq0pksqsjg00yi5d8vz7np3hcz9p7mps-source/nix/derivation.nix:18
         Use pytestFlags or (enabled|disabled)(TestPaths|Tests|TestMarks) instead.
```

After:

```console
$ nix build
$
```